### PR TITLE
added setInsecure for esp32

### DIFF
--- a/src/Tiny_Websockets_Generic/client.hpp
+++ b/src/Tiny_Websockets_Generic/client.hpp
@@ -205,7 +205,6 @@ namespace websockets2_generic
       const char* _optional_ssl_ca_cert = nullptr;
       const char* _optional_ssl_client_ca = nullptr;
       const char* _optional_ssl_private_key = nullptr;
-      bool _use_insecure;
   #endif
   
       void _handlePing(WebsocketsMessage);

--- a/src/Tiny_Websockets_Generic/client.hpp
+++ b/src/Tiny_Websockets_Generic/client.hpp
@@ -205,6 +205,7 @@ namespace websockets2_generic
       const char* _optional_ssl_ca_cert = nullptr;
       const char* _optional_ssl_client_ca = nullptr;
       const char* _optional_ssl_private_key = nullptr;
+      bool _use_insecure;
   #endif
   
       void _handlePing(WebsocketsMessage);

--- a/src/Tiny_Websockets_Generic/network/esp32/esp32_tcp.hpp
+++ b/src/Tiny_Websockets_Generic/network/esp32/esp32_tcp.hpp
@@ -64,6 +64,11 @@ namespace websockets2_generic
         {
           this->client.setPrivateKey(private_key);
         }
+
+        void setInsecure()
+        {
+            this->client.setInsecure();
+        }
     };
     
     

--- a/src/WebSockets2_Generic_Client.hpp
+++ b/src/WebSockets2_Generic_Client.hpp
@@ -429,7 +429,7 @@ namespace websockets2_generic
     
   #elif defined(ESP32)
 
-    if (!this->_use_insecure)
+    if (this->_optional_ssl_ca_cert || this->_optional_ssl_client_ca || this->_optional_ssl_private_key)
     {
         if (this->_optional_ssl_ca_cert)
         {
@@ -1028,7 +1028,6 @@ namespace websockets2_generic
     this->_optional_ssl_ca_cert = nullptr;
     this->_optional_ssl_client_ca = nullptr;
     this->_optional_ssl_private_key = nullptr;
-    this->_use_insecure = true;
   }
   #endif
   

--- a/src/WebSockets2_Generic_Client.hpp
+++ b/src/WebSockets2_Generic_Client.hpp
@@ -429,19 +429,26 @@ namespace websockets2_generic
     
   #elif defined(ESP32)
 
-    if (this->_optional_ssl_ca_cert) 
+    if (!this->_use_insecure)
     {
-      client->setCACert(this->_optional_ssl_ca_cert);
+        if (this->_optional_ssl_ca_cert)
+        {
+            client->setCACert(this->_optional_ssl_ca_cert);
+        }
+
+        if (this->_optional_ssl_client_ca)
+        {
+            client->setCertificate(this->_optional_ssl_client_ca);
+        }
+
+        if (this->_optional_ssl_private_key)
+        {
+            client->setPrivateKey(this->_optional_ssl_private_key);
+        }
     }
-    
-    if (this->_optional_ssl_client_ca) 
+    else
     {
-      client->setCertificate(this->_optional_ssl_client_ca);
-    }
-    
-    if (this->_optional_ssl_private_key) 
-    {
-      client->setPrivateKey(this->_optional_ssl_private_key);
+        client->setInsecure();
     }
     
   #endif
@@ -1021,6 +1028,7 @@ namespace websockets2_generic
     this->_optional_ssl_ca_cert = nullptr;
     this->_optional_ssl_client_ca = nullptr;
     this->_optional_ssl_private_key = nullptr;
+    this->_use_insecure = true;
   }
   #endif
   


### PR DESCRIPTION
I've added the setInsecure fonction to be able to work with self signed certificate, it's really usefull in dev ;)

Usage example in Secured ESP32 Websockets Client:
replace client.setCACert(echo_org_ssl_ca_cert); by client.setInsecure(); and voila, it's working