### PR TITLE
Added ESP32 WiFiClientSecure::setCACertBundle().

### DIFF
--- a/src/Tiny_Websockets_Generic/client.hpp
+++ b/src/Tiny_Websockets_Generic/client.hpp
@@ -169,6 +169,7 @@ namespace websockets2_generic
       //////
   #elif defined(ESP32)
       void setCACert(const char* ca_cert);
+      void setCACertBundle(const uint8_t* ca_cert_bundle);
       void setCertificate(const char* client_ca);
       void setPrivateKey(const char* private_key);
   #endif
@@ -211,6 +212,7 @@ namespace websockets2_generic
       //////
   #elif defined(ESP32)
       const char* _optional_ssl_ca_cert = nullptr;
+      const uint8_t* _optional_ssl_ca_cert_bundle = nullptr;
       const char* _optional_ssl_client_ca = nullptr;
       const char* _optional_ssl_private_key = nullptr;
   #endif

--- a/src/Tiny_Websockets_Generic/network/esp32/esp32_tcp.hpp
+++ b/src/Tiny_Websockets_Generic/network/esp32/esp32_tcp.hpp
@@ -48,6 +48,11 @@ namespace websockets2_generic
           this->client.setCACert(ca_cert);
         }
     
+        void setCACertBundle(const uint8_t* ca_cert_bundle)
+        {
+          this->client.setCACertBundle(ca_cert_bundle);
+        }
+
         void setCertificate(const char* client_ca)
         {
           this->client.setCertificate(client_ca);

--- a/src/WebSockets2_Generic_Client.hpp
+++ b/src/WebSockets2_Generic_Client.hpp
@@ -458,11 +458,17 @@ namespace websockets2_generic
     
   #elif defined(ESP32)
 
-    if (this->_optional_ssl_ca_cert || this->_optional_ssl_client_ca || this->_optional_ssl_private_key)
+    if (this->_optional_ssl_ca_cert || this->_optional_ssl_ca_cert_bundle ||
+        this->_optional_ssl_client_ca || this->_optional_ssl_private_key)
     {
       if (this->_optional_ssl_ca_cert)
       {
         client->setCACert(this->_optional_ssl_ca_cert);
+      }
+
+      if (this->_optional_ssl_ca_cert_bundle)
+      {
+        client->setCACertBundle(this->_optional_ssl_ca_cert_bundle);
       }
 
       if (this->_optional_ssl_client_ca)
@@ -1119,6 +1125,13 @@ namespace websockets2_generic
   
   /////////////////////////////////////////////////////////
 
+  void WebsocketsClient::setCACertBundle(const uint8_t* ca_cert_bundle)
+  {
+    this->_optional_ssl_ca_cert_bundle = ca_cert_bundle;
+  }
+
+  /////////////////////////////////////////////////////////
+
   void WebsocketsClient::setCertificate(const char* client_ca)
   {
     this->_optional_ssl_client_ca = client_ca;
@@ -1136,6 +1149,7 @@ namespace websockets2_generic
   void WebsocketsClient::setInsecure()
   {
     this->_optional_ssl_ca_cert = nullptr;
+    this->_optional_ssl_ca_cert_bundle = nullptr;
     this->_optional_ssl_client_ca = nullptr;
     this->_optional_ssl_private_key = nullptr;
   }


### PR DESCRIPTION
WiFiClientSecure can now use a bundle of certificates to authenticate a
server.  See espressif/arduino-esp32#6106